### PR TITLE
Changes to support WSREP_SYNC_WAIT_UPTO()

### DIFF
--- a/wsrep_api.h
+++ b/wsrep_api.h
@@ -210,6 +210,18 @@ wsrep_uuid_scan (const char* str, size_t str_len, wsrep_uuid_t* uuid);
 extern int
 wsrep_uuid_print (const wsrep_uuid_t* uuid, char* str, size_t str_len);
 
+/*!
+ * @brief Compare two UUIDs
+ *
+ * Performs a byte by byte comparison of lhs and rhs.
+ * Returns 0 if lhs and rhs match, otherwise -1 or 1 according to the
+ * difference of the first byte that differs in lsh and rhs.
+ *
+ * @return -1, 0, 1 if lhs is respectively smaller, equal, or greater than rhs
+ */
+extern int
+wsrep_uuid_compare (const wsrep_uuid_t* lhs, const wsrep_uuid_t* rhs);
+
 #define WSREP_MEMBER_NAME_LEN 32  //!< maximum logical member name length
 #define WSREP_INCOMING_LEN    256 //!< max Domain Name length + 0x00
 
@@ -865,18 +877,33 @@ struct wsrep {
                                   wsrep_bool_t            copy);
 
   /*!
-   * @brief Get causal ordering for read operation
+   * @brief Blocks until the given GTID is committed
    *
-   * This call will block until causal ordering with all possible
-   * preceding writes in the cluster is guaranteed. If pointer to
-   * gtid is non-null, the call stores the global transaction ID
-   * of the last transaction which is guaranteed to be ordered
-   * causally before this call.
+   * This call will block the caller until the given GTID
+   * is guaranteed to be committed.
+   * If no pointer upto is provided the call will block until
+   * causal ordering with all possible preceding writes in the
+   * cluster is guaranteed.
+   *
+   * If pointer to gtid is non-null, the call stores the global
+   * transaction ID of the last transaction which is guaranteed
+   * to be committed when the call returns.
    *
    * @param wsrep provider handle
+   * @param upto  gtid to wait upto
    * @param gtid  location to store GTID
    */
-    wsrep_status_t (*causal_read)(wsrep_t* wsrep, wsrep_gtid_t* gtid);
+    wsrep_status_t (*sync_wait)(wsrep_t*      wsrep,
+                                wsrep_gtid_t* upto,
+                                wsrep_gtid_t* gtid);
+
+  /*!
+   * @brief Returns the last committed gtid
+   *
+   * @param gtid location to store GTID
+   */
+    wsrep_status_t (*last_committed_id)(wsrep_t*      wsrep,
+                                        wsrep_gtid_t* gtid);
 
   /*!
    * @brief Clears allocated connection context.

--- a/wsrep_dummy.c
+++ b/wsrep_dummy.c
@@ -191,7 +191,16 @@ static wsrep_status_t dummy_append_data(
     return WSREP_OK;
 }
 
-static wsrep_status_t dummy_causal_read(
+static wsrep_status_t dummy_sync_wait(
+    wsrep_t* w,
+    wsrep_gtid_t* upto __attribute__((unused)),
+    wsrep_gtid_t* gtid __attribute__((unused)))
+{
+    WSREP_DBUG_ENTER(w);
+    return WSREP_OK;
+}
+
+static wsrep_status_t dummy_last_committed_id(
     wsrep_t* w,
     wsrep_gtid_t* gtid __attribute__((unused)))
 {
@@ -372,7 +381,8 @@ static wsrep_t dummy_iface = {
     &dummy_abort_pre_commit,
     &dummy_append_key,
     &dummy_append_data,
-    &dummy_causal_read,
+    &dummy_sync_wait,
+    &dummy_last_committed_id,
     &dummy_free_connection,
     &dummy_to_execute_start,
     &dummy_to_execute_end,

--- a/wsrep_uuid.c
+++ b/wsrep_uuid.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "wsrep_api.h"
 
@@ -80,4 +81,14 @@ wsrep_uuid_print (const wsrep_uuid_t* uuid, char* str, size_t str_len)
     else {
         return -EMSGSIZE;
     }
+}
+
+/*!
+ * Compare two UUIDs
+ * @return -1, 0, 1 if lhs is respectively smaller, equal, or greater than rhs
+ */
+int
+wsrep_uuid_compare (const wsrep_uuid_t* lhs, const wsrep_uuid_t* rhs)
+{
+    return memcmp(lhs, rhs, sizeof(wsrep_uuid_t));
 }


### PR DESCRIPTION
- Renamed wsrep->causal_wait() to wsrep->sync_wait().
  The function now takes an extra parameter: upto,
  which is the gtid to wait for.

- Added function wsrep_uuid_compare() and wsrep_gtid_compare().