### PR TITLE
GCF-487, GCF-788 reworked control flow for local transaction commits:

### DIFF
--- a/wsrep_dummy.c
+++ b/wsrep_dummy.c
@@ -133,7 +133,7 @@ static wsrep_status_t dummy_pre_commit(
     return WSREP_OK;
 }
 
-static wsrep_status_t dummy_post_commit(
+static wsrep_status_t dummy_post_rollback(
     wsrep_t* w,
     wsrep_ws_handle_t*  ws_handle  __attribute__((unused)))
 {
@@ -141,7 +141,7 @@ static wsrep_status_t dummy_post_commit(
     return WSREP_OK;
 }
 
-static wsrep_status_t dummy_post_rollback(
+static wsrep_status_t dummy_release(
     wsrep_t* w,
     wsrep_ws_handle_t*  ws_handle  __attribute__((unused)))
 {
@@ -377,8 +377,8 @@ static wsrep_t dummy_iface = {
     &dummy_recv,
     &dummy_assign_read_view,
     &dummy_pre_commit,
-    &dummy_post_commit,
     &dummy_post_rollback,
+    &dummy_release,
     &dummy_replay_trx,
     &dummy_abort_pre_commit,
     &dummy_append_key,

--- a/wsrep_loader.c
+++ b/wsrep_loader.c
@@ -67,8 +67,8 @@ static int verify(const wsrep_t *wh, const char *iface_ver)
     VERIFY(wh->recv);
     VERIFY(wh->assign_read_view);
     VERIFY(wh->pre_commit);
-    VERIFY(wh->post_commit);
     VERIFY(wh->post_rollback);
+    VERIFY(wh->release);
     VERIFY(wh->replay_trx);
     VERIFY(wh->abort_pre_commit);
     VERIFY(wh->append_key);


### PR DESCRIPTION
  1. `post_rollback()` method changed semantics. Instead of releasing resources out of order after forced transaction rollback, now it enters TO critical section if transaction was totally ordered.
  2. `post_commit()` method was renamed `release()` since now it is called after either commit or rollback.