### PR TITLE
Method abort_pre_commit() required to report BF abort success.

### DIFF
--- a/wsrep_api.h
+++ b/wsrep_api.h
@@ -168,7 +168,8 @@ typedef enum wsrep_status
     WSREP_CONN_FAIL,       //!< error in client connection, must abort
     WSREP_NODE_FAIL,       //!< error in node state, wsrep must reinit
     WSREP_FATAL,           //!< fatal error, server must abort
-    WSREP_NOT_IMPLEMENTED  //!< feature not implemented
+    WSREP_NOT_IMPLEMENTED, //!< feature not implemented
+    WSREP_NOT_ALLOWED      //!< operation not allowed
 } wsrep_status_t;
 
 
@@ -837,16 +838,23 @@ struct wsrep {
    * The kill routine checks that abort is not attmpted against a transaction
    * which is front of the caller (in total order).
    *
+   * If the abort was successful, the victim sequence number is stored
+   * into location pointed by the victim_seqno.
+   *
    * @param wsrep      provider handle
    * @param bf_seqno   seqno of brute force trx, running this cancel
    * @param victim_trx transaction to be aborted, and which is committing
+   * @param victim_seqno seqno of the victim transaction if assigned
    *
-   * @retval WSREP_OK       abort secceded
-   * @retval WSREP_WARNING  abort failed
+   * @retval WSREP_OK          abort succeded
+   * @retval WSREP_NOT_ALLOWED the provider declined the abort request
+   * @retval WSREP_TRX_MISSING the victim_trx was missing
+   * @retval WSREP_WARNING     abort failed
    */
     wsrep_status_t (*abort_pre_commit)(wsrep_t*       wsrep,
                                        wsrep_seqno_t  bf_seqno,
-                                       wsrep_trx_id_t victim_trx);
+                                       wsrep_trx_id_t victim_trx,
+                                       wsrep_seqno_t* victim_seqno);
 
   /*!
    * @brief Send a rollback fragment on behalf of trx

--- a/wsrep_dummy.c
+++ b/wsrep_dummy.c
@@ -86,7 +86,7 @@ static wsrep_status_t dummy_options_set(
 static char* dummy_options_get (wsrep_t* w)
 {
     WSREP_DBUG_ENTER(w);
-    return WSREP_DUMMY(w)->options;
+    return strdup(WSREP_DUMMY(w)->options);
 }
 
 static wsrep_status_t dummy_connect(
@@ -161,7 +161,8 @@ static wsrep_status_t dummy_replay_trx(
 static wsrep_status_t dummy_abort_pre_commit(
     wsrep_t* w,
     const wsrep_seqno_t  bf_seqno __attribute__((unused)),
-    const wsrep_trx_id_t trx_id   __attribute__((unused)))
+    const wsrep_trx_id_t trx_id   __attribute__((unused)),
+    wsrep_seqno_t *victim_seqno __attribute__((unused)))
 {
     WSREP_DBUG_ENTER(w);
     return WSREP_OK;


### PR DESCRIPTION
Changed abort_pre_commit() requirements so that more information
about BF abort success is propageted to the caller. The call is
now required to return:

* WSREP_TRX_MISSING if the provider could not perform BF abort
  if the victim_trx was not found by the provider
* WSREP_TRX_FAIL if the provider declined to perform BF abort
  for any other reason

Additionally the abort_pre_commit() is now required to return
victim_seqno if the BF abort was succesful. This is needed
if the commit ordering management is done in the application
which uses wsrep provider.