### PR TITLE
Refs codership/wsrep-API#35 Added IMPLICIT_DEPS flag

### DIFF
--- a/wsrep_api.h
+++ b/wsrep_api.h
@@ -132,6 +132,7 @@ typedef void (*wsrep_log_cb_t)(wsrep_log_level_t, const char *);
 #define WSREP_FLAG_PA_UNSAFE            ( 1ULL << 3 )
 #define WSREP_FLAG_COMMUTATIVE          ( 1ULL << 4 )
 #define WSREP_FLAG_NATIVE               ( 1ULL << 5 )
+#define WSREP_FLAG_IMPLICIT_DEPS        ( 1ULL << 9 )
 
 
 typedef uint64_t wsrep_trx_id_t;  //!< application transaction ID


### PR DESCRIPTION
for individual reduction of PA range per writeset for transactions
that can't reference all dependencies in a keyset (like parent keys)

This is a backport from v26 in case we need it