### PR TITLE
Add tls stream pointer to error message function

### DIFF
--- a/wsrep_dummy.c
+++ b/wsrep_dummy.c
@@ -43,6 +43,8 @@ typedef struct wsrep_dummy
 
 static void dummy_free(wsrep_t *w)
 {
+    if (!w->ctx) return;
+
     WSREP_DBUG_ENTER(w);
     if (WSREP_DUMMY(w)->options) {
         free(WSREP_DUMMY(w)->options);

--- a/wsrep_tls_service.h
+++ b/wsrep_tls_service.h
@@ -189,6 +189,7 @@ typedef const void* (*wsrep_tls_stream_get_error_category_t)(
  */
 typedef const char* (*wsrep_tls_error_message_get_t)(
     wsrep_tls_context_t*,
+    const wsrep_tls_stream_t* stream,
     int error_number, const void* category);
 
 /**


### PR DESCRIPTION
The stream context may be needed by the application to
store extra error information for human readable
error messages.

Fix to dummy provider: Return immediately from free()
if it has already been called.